### PR TITLE
Bug/#3 api key prompt on demand

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,14 +18,15 @@ import Index from "./pages/Index";
 const queryClient = new QueryClient();
 
 const App = () => {
-  const [hasKey, setHasKey] = useState(!!localStorage.getItem("geminiApiKey"));
-  const [showPrompt, setShowPrompt] = useState(false);
+  const [hasKey, setHasKey] = useState(false);
 
   useEffect(() => {
-    if (!localStorage.getItem("geminiApiKey")) {
-      setShowPrompt(true);
-    }
+    const key = localStorage.getItem("geminiApiKey");
+    setHasKey(!!key);
   }, []);
+
+  // console.log(localStorage.getItem("geminiApiKey"));
+  // console.log("Has key:", hasKey);
 
   return (
     <ThemeProvider defaultTheme="dark">
@@ -33,14 +34,6 @@ const App = () => {
         <TooltipProvider>
           <Toaster />
           <Sonner />
-          <ApiKeyPrompt
-            open={showPrompt}
-            onClose={() => setShowPrompt(false)}
-            onSave={() => {
-              setShowPrompt(false);
-              setHasKey(true);
-            }}
-          />
           <BrowserRouter>
             <Routes>
               <Route path="/" element={<Index />} />

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -17,14 +17,14 @@ import Layout from "@/components/layout/Layout";
 import { mockTopics, mockQuestions } from "@/lib/mock-data";
 
 const ExplorePage = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const navigate = useNavigate();
+
   // Check for Gemini API key
   if (!localStorage.getItem("geminiApiKey")) {
     window.location.href = "/";
     return null;
   }
-
-  const [searchQuery, setSearchQuery] = useState("");
-  const navigate = useNavigate();
 
   // Create trending topics - just using mock data
   const trendingTopics = mockTopics.slice(0, 3);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,16 +18,16 @@ import { toast } from "sonner";
 import { mockTopics, Topic } from "@/lib/mock-data";
 
 const HomePage = () => {
+  const [showNewTopicForm, setShowNewTopicForm] = useState(false);
+  const [newTopic, setNewTopic] = useState({ title: "", description: "" });
+  const [topics, setTopics] = useState<Topic[]>(mockTopics);
+  const navigate = useNavigate();
+
   // Check for Gemini API key
   if (!localStorage.getItem("geminiApiKey")) {
     window.location.href = "/";
     return null;
   }
-
-  const [showNewTopicForm, setShowNewTopicForm] = useState(false);
-  const [newTopic, setNewTopic] = useState({ title: "", description: "" });
-  const [topics, setTopics] = useState<Topic[]>(mockTopics);
-  const navigate = useNavigate();
 
   const handleCreateTopic = () => {
     if (!newTopic.title.trim()) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,6 +27,8 @@ const Index = () => {
     }
   };
 
+  console.log("showApiKeyPrompt:", showApiKeyPrompt)
+
   return (
     <div className="flex min-h-screen flex-col">
       {/* Navbar */}
@@ -268,11 +270,14 @@ const Index = () => {
         </div>
       </footer>
 
-      <ApiKeyPrompt
-        open={showApiKeyPrompt}
-        onClose={() => setShowApiKeyPrompt(false)}
-        onSave={() => navigate("/home")}
-      />
+      {showApiKeyPrompt && (
+        <ApiKeyPrompt
+          open={showApiKeyPrompt}
+          onClose={() => setShowApiKeyPrompt(false)}
+          // onSave={() => navigate("/home")}
+          onSave={() => window.location.reload()}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,7 +27,7 @@ const Index = () => {
     }
   };
 
-  console.log("showApiKeyPrompt:", showApiKeyPrompt)
+  // console.log("showApiKeyPrompt:", showApiKeyPrompt)
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/src/pages/TopicDetailPage.tsx
+++ b/src/pages/TopicDetailPage.tsx
@@ -33,11 +33,6 @@ import { toast } from "sonner";
 import { mockTopics, mockQuestions, Topic, Question } from "@/lib/mock-data";
 
 const TopicDetailPage = () => {
-  if (!localStorage.getItem("geminiApiKey")) {
-    window.location.href = "/";
-    return null;
-  }
-
   const { id } = useParams<{ id: string }>();
   const [topic, setTopic] = useState<Topic | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
@@ -59,6 +54,11 @@ const TopicDetailPage = () => {
       setQuestions(topicQuestions);
     }
   }, [id]);
+
+  if (!localStorage.getItem("geminiApiKey")) {
+    window.location.href = "/";
+    return null;
+  }
 
   const handleAddQuestion = async () => {
     if (!newQuestionLink.trim()) {


### PR DESCRIPTION
# 📝 Pull Request Description

## 📌 Title  
**PR Title:** Bug: Show Gemini API Prompt Only After 'Get Started'

Fixes: #3 

Before: 

https://github.com/user-attachments/assets/08dbae51-9376-40a8-9b17-78c438a359e2



After: 

https://github.com/user-attachments/assets/add62691-88ee-4ef1-a98a-220c0b4da4eb



---

## 🛠️ What does this PR do?

- Removes auto-triggering of the Gemini API key prompt on initial load  
- Ensures the prompt is only shown when the user explicitly clicks **"Get Started"**  
- Centralizes API key input logic inside `Index.tsx`  
- Cleans up redundant state and side effects in `App.tsx`  

---

## 🔍 Related Issues  
Closes:  
Related to: 

---

## 💡 Type of Change  

- [x] Code refactor  
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Test improvement  
- [ ] CI/CD improvement  
- [ ] Other:

---

## 🧪 How to Test

1. Clear `localStorage` to simulate a first-time visitor  
2. Open the app → confirm that **no prompt appears immediately**  
3. Click **Get Started** → Gemini API prompt should appear  
4. Enter a valid API key → you should be redirected to `/home`  
5. Refresh → user stays on `/home` without re-prompting

---

## ✅ Checklist  

- [x] Code compiles without errors  
- [x] Linting passes  
- [x] Manual test confirms behavior  
- [ ] I’ve added/updated documentation (not applicable)  
- [x] PR follows the project’s code style and guidelines

---

## 🗒️ Additional Notes  

This change improves UX by removing intrusive prompts on first load.  
It prepares the onboarding experience for a more user-friendly flow.  
A future improvement could be to migrate API key state into a global context.
